### PR TITLE
fix: use direct TTL field access instead of pointer arithmetic

### DIFF
--- a/unbound.go
+++ b/unbound.go
@@ -47,11 +47,10 @@ struct ub_result *new_ub_result() {
 	r = calloc(sizeof(struct ub_result), 1);
 	return r;
 }
-int    ub_ttl(struct ub_result *r) {
-	int *p;
-	// Go to why_bogus add the pointer and then we will find the ttl, hopefully.
-	p = (int*) ((char*)r + offsetof(struct ub_result, why_bogus) + sizeof(char*));
-	return (int)*p;
+int	ub_ttl(struct ub_result *r) {
+	 // FIXED: Modern libunbound (1.4.20+) has a direct ttl field in struct ub_result
+	 // No need for dangerous pointer arithmetic - just access r->ttl directly
+	 return r->ttl;
 }
 */
 import "C"


### PR DESCRIPTION
Modern libunbound (1.4.20+) has a direct 'ttl' field in struct ub_result.
The previous pointer arithmetic approach was fragile and often returned 0.
This fix directly accesses r->ttl which is reliable and safe.

Fixes TTL=0 issue with libunbound 1.19.2 and other modern versions.

Tested with libunbound 1.19.2 on Ubuntu 24.04.